### PR TITLE
Add ability to upload photos when submitting a complaint 

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -58,7 +58,7 @@ config :komplen, KomplenWeb.Endpoint,
 config :komplen, KomplenWeb.Endpoint,
   live_reload: [
     patterns: [
-      ~r"priv/static/.*(js|css|png|jpeg|jpg|gif|svg)$",
+      ~r"priv/static/[^uploads].*(js|css|png|jpeg|jpg|gif|svg)$",
       ~r"priv/gettext/.*(po)$",
       ~r"lib/komplen_web/(live|views)/.*(ex)$",
       ~r"lib/komplen_web/templates/.*(eex)$"

--- a/lib/komplen/complaints/complaint.ex
+++ b/lib/komplen/complaints/complaint.ex
@@ -11,6 +11,7 @@ defmodule Komplen.Complaints.Complaint do
     field :status, :string
     field :lat, :string
     field :lng, :string
+    field :photo_urls, {:array, :string}, default: []
     belongs_to :user, User
     has_one :room, Room
 
@@ -20,7 +21,7 @@ defmodule Komplen.Complaints.Complaint do
   @doc false
   def changeset(complaint, attrs) do
     complaint
-    |> cast(attrs, [:title, :body, :status, :lat, :lng])
+    |> cast(attrs, [:title, :body, :status, :lat, :lng, :photo_urls])
     |> validate_required([:title, :body, :user_id])
     |> check_constraint(:status, name: :allowed_status)
     |> assoc_constraint(:user)

--- a/lib/komplen_web/endpoint.ex
+++ b/lib/komplen_web/endpoint.ex
@@ -24,7 +24,7 @@ defmodule KomplenWeb.Endpoint do
     at: "/",
     from: :komplen,
     gzip: false,
-    only: ~w(css fonts images js favicon.ico robots.txt)
+    only: ~w(css fonts images js favicon.ico robots.txt uploads)
 
   # Code reloading can be explicitly enabled under the
   # :code_reloader configuration of your endpoint.

--- a/lib/komplen_web/live/complaint_live/form_component.html.heex
+++ b/lib/komplen_web/live/complaint_live/form_component.html.heex
@@ -25,6 +25,40 @@
 
     <%= hidden_input f, :lat %>
     <%= hidden_input f, :lng %>
+
+    <%# Phoenix.LiveView.Helpers.upload_errors/2 returns a list of error atoms %>
+    <%= for {_ref, msg} <- @uploads.avatar.errors do %>
+      <p><%= Phoenix.Naming.humanize(msg) %></p>
+    <% end %>
+
+    <%= for url <- @uploaded_files do %>
+      <div>
+        <img src={url} height="300px">
+        <button type="button" phx-click="remove-uploaded" phx-value-url={url} phx-target={@myself}>remove</button>
+      </div>
+    <% end %>
+
+    <%= live_file_input @uploads.avatar %>
+    <%= for entry <- @uploads.avatar.entries do %>
+      <article>
+        <figure>
+          <%# Phoenix.LiveView.Helpers.live_img_preview/2 renders a client-side preview %>
+          <%= live_img_preview entry, height: 120 %>
+          <figcaption><%= entry.client_name %></figcaption>
+        </figure>
+
+        <%# entry.progress will update automatically for in-flight entries %>
+        <progress value={entry.progress} max="100"> <%= entry.progress %>% </progress>
+
+        <button type="button" phx-click="cancel-upload" phx-value-ref={entry.ref} phx-target={@myself} aria-label="cancel">&times;</button>
+
+        <%# Phoenix.LiveView.Helpers.upload_errors/2 returns a list of error atoms %>
+        <%= for err <- upload_errors(@uploads.avatar, entry) do %>
+          <p><%= error_to_string(err) %></p>
+        <% end %>
+
+      </article>
+    <% end %>
     <div>
       <%= submit "Save", phx_disable_with: "Saving..." %>
     </div>

--- a/lib/komplen_web/live/complaint_live/show.html.heex
+++ b/lib/komplen_web/live/complaint_live/show.html.heex
@@ -30,6 +30,12 @@
     <strong>Num vouches:</strong>
     <%= @num_vouches %>
   </li>
+
+  <%= for url <- @complaint.photo_urls do %>
+    <li>
+      <img src={url} height="300px">
+    </li>
+  <% end %>
 </ul>
 
 Status: <%= @complaint.status %>

--- a/priv/repo/migrations/20210913142918_create_complaints.exs
+++ b/priv/repo/migrations/20210913142918_create_complaints.exs
@@ -7,6 +7,9 @@ defmodule Komplen.Repo.Migrations.CreateComplaints do
       add :body, :text
       add :lat, :text
       add :lng, :text
+      # YOGHIRT
+      # this type syntax can be found here https://hexdocs.pm/ecto/Ecto.Schema.html#module-types-and-casting
+      add :photo_urls, {:array, :string}, default: []
 
       timestamps()
     end


### PR DESCRIPTION
# Description

* Add a photo uploader when creating a new complaint. This will save a file on the local filesystem and store that path in the database
* Able to remove the photos as well when editing the complaint. This will remove the file from the local filesystem

# Trello

- https://trello.com/c/4Qb9OGR8
- https://trello.com/c/Y1LcCtrn